### PR TITLE
Minor docs addition for Enum.member?/2

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ iex> Enum.map Qex.new([1, 2, 3]), &(&1 + 1)
 
 iex> inspect Enum.into(1..5, %Qex{})
 "#Qex<[1, 2, 3, 4, 5]>"
+
+# Leverages :queue.member/2 under the hood for performance
+iex> Enum.member? Qex.new(1..10_000), 9_999
+true
 ```
 
 #### Create a new queue from a range


### PR DESCRIPTION
This is the world's goofiest PR, and if you don't want it, no hard feelings whatsoever. 😄 

The story here is: I'd been using `:queue` directly and wanted to switch to this, but I couldn't figure out why there wasn't a `Qex.member?/2` function. In retrospect, it's obvious: the Enumerable implementation supports fast-checking membership, but because I couldn't find "member?" on the docs page, I assumed it wasn't there.

Anyway, as I say, I might be the only person in the world who wouldn't intuitively "get" this. Your call. ☺️