### PR TITLE
Make Qex.split/2 match the behavior of Enum.split/2 rather than :queue.split/2

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ iex> Enum.map Qex.new([1, 2, 3]), &(&1 + 1)
 
 iex> inspect Enum.into(1..5, %Qex{})
 "#Qex<[1, 2, 3, 4, 5]>"
+
+# Leverages :queue.member/2 under the hood for performance
+iex> Enum.member? Qex.new(1..10_000), 9_999
+true
 ```
 
 #### Create a new queue from a range

--- a/lib/qex.ex
+++ b/lib/qex.ex
@@ -147,7 +147,11 @@ defmodule Qex do
   end
 
   @doc """
-  Split a queue into two, the front n items are put in the first queue
+  Split a queue into two, the front n items (up to all items) are put in the first queue
+
+  Unlike :queue.split/2, which raises an ArgumentError when you ask to split more elements,
+  this matches the behavior of Enum.split/2 by silently returning the minimum of the
+  requested number of items and the complete queue.
 
       iex> q = Qex.new 1..5
       iex> {q1, q2} = Qex.split(q, 3)
@@ -155,10 +159,17 @@ defmodule Qex do
       [1, 2, 3]
       iex> Enum.to_list q2
       [4, 5]
+      iex> {q_full, q_empty} = Qex.split(q, 1_000)
+      iex> Enum.to_list q_full
+      [1, 2, 3, 4, 5]
+      iex> Enum.to_list q_empty
+      []
   """
   @spec split(t, pos_integer) :: {t, t}
   def split(%__MODULE__{data: q}, n) do
-    with {q1, q2} <- :queue.split(n, q) do
+    count = min(:queue.len(q), n)
+
+    with {q1, q2} <- :queue.split(count, q) do
       {%__MODULE__{data: q1}, %__MODULE__{data: q2}}
     end
   end


### PR DESCRIPTION
This changes the behavior of `Qex.split/2` to be less surprising to Elixir devs.

When you ask for more elements than your queue currently contains, it will silently return the complete queue as the first item in the tuple, rather than throwing an `ArgumentError` like `:queue.split/2` does when you ask for too many items.

Thus, instead of matching this behavior:

```
iex(1)> :queue.split(:queue.new(), 3)
** (ArgumentError) argument error
    (stdlib 3.14.1) queue.erl:336: :queue.split({[], []}, 3)
```

...it behaves like this:

```
iex(2)> Enum.split(Qex.new(), 3)
{[], []}
```

...giving you:

```
iex(3)> Qex.split(Qex.new(), 3)
{#Qex<[]>, #Qex<[]>}
```

This is a _potentially_ breaking change, in the sense that somebody could conceivably be depending on an `ArgumentError` to tell them they asked for more than `:queue.len/1` elements. (One alternative might be to call this version `safe_split/2` or something and leave the existing `split/2` behavior in place.) I suspect there are a great many _more_ folks new to working with queues on the BEAM who are bitten by this unexpectedly raising an error, though.

This might controversial, so again, no hard feelings if you don't want it. ☺️