### PR TITLE
Misc doc changes

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,26 @@
 # The directory Mix will write compiled artifacts to.
-/_build
+/_build/
 
 # If you run "mix test --cover", coverage assets end up here.
-/cover
+/cover/
 
 # The directory Mix downloads your dependencies sources to.
-/deps
+/deps/
 
-# Where 3rd-party dependencies like ExDoc output generated docs.
-/doc
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
 
 # If the VM crashes, it generates a dump, let's ignore it too.
 erl_crash.dump
 
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+
+# Ignore package tarball (built via "mix hex.build").
+qex-*.tar
+
+# Temporary files, for example, from tests.
+/tmp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-## v0.5.0
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## v0.5.0 (2018-09-04)
 
 ### Added
 - `first/1`, `first!/1`, `last/1`, `last!/1`

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-MIT License
+# The MIT License
 
 Copyright (c) 2018 Po Chen
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
-# Qex [![Hex.pm](https://img.shields.io/hexpm/v/qex.svg)](https://hex.pm/packages/qex) [![Documentation](https://img.shields.io/badge/docs-hexpm-blue.svg)](https://hexdocs.pm/qex/Qex.html)
+# Qex
+
+[![Elixir CI](https://github.com/princemaple/elixir-queue/actions/workflows/elixir.yml/badge.svg)](https://github.com/princemaple/elixir-queue/actions/workflows/elixir.yml)
+[![Module Version](https://img.shields.io/hexpm/v/qex.svg)](https://hex.pm/packages/qex)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/qex/)
+[![Total Download](https://img.shields.io/hexpm/dt/qex.svg)](https://hex.pm/packages/qex)
+[![License](https://img.shields.io/hexpm/l/qex.svg)](https://github.com/princemaple/elixir-queue/blob/master/LICENSE.md)
+[![Last Updated](https://img.shields.io/github/last-commit/princemaple/elixir-queue.svg)](https://github.com/princemaple/elixir-queue/commits/master)
 
 A `:queue` wrapper with improvements in API and addition of Protocol implementations
 
@@ -15,15 +22,17 @@ Parameters are re-ordered to better suit Elixir's awesome `|>`
 
 The package can be installed as:
 
-  1. Add `qex` to your list of dependencies in `mix.exs`:
+1. Add `:qex` to your list of dependencies in `mix.exs`:
 
-```elixir
-def deps do
-  [{:qex, "~> 0.5"}]
-end
-```
+   ```elixir
+   def deps do
+     [
+       {:qex, "~> 0.5"}
+     ]
+   end
+   ```
 
-  2. Run `mix deps.get`
+2. Run `mix deps.get`
 
 ## How to use
 
@@ -173,3 +182,10 @@ iex> Qex.last!(q1)
 ## Why not "Queue"?
 
 The name is taken... [Hex link](https://hex.pm/packages/queue)
+
+## Copyright and License
+
+Copyright (c) 2018 Po Chen
+
+This work is free. You can redistribute it and/or modify it under the
+terms of the MIT License. See the [LICENSE.md](./LICENSE.md) file for more details.

--- a/mix.exs
+++ b/mix.exs
@@ -7,21 +7,14 @@ defmodule Qex.Mixfile do
   def project do
     [
       app: :qex,
+      name: "Qex",
       version: @version,
       elixir: "~> 1.9",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       deps: deps(),
-
-      # Hex
-      description: description(),
-      package: package(),
-
-      # Docs
-      name: "Qex",
-      source_url: @source_url,
-      homepage_url: @source_url,
-      docs: docs()
+      docs: docs(),
+      package: package()
     ]
   end
 
@@ -33,25 +26,31 @@ defmodule Qex.Mixfile do
     [{:ex_doc, ">= 0.0.0", only: :docs, runtime: false}]
   end
 
-  defp description do
-    "A `:queue` wrapper with improvements in API and addition of Protocol implementations"
-  end
-
   defp package do
     [
+      description:
+        "A `:queue` wrapper with improvements in API and addition of Protocol implementations",
       licenses: ["MIT"],
       maintainers: ["Po Chen"],
-      links: %{GitHub: "https://github.com/princemaple/elixir-queue"}
+      links: %{
+        Changelog: "https://hexdocs.pm/qex/changelog.html",
+        GitHub: @source_url
+      }
     ]
   end
 
   defp docs do
     [
-      source_ref: "v#{@version}",
-      main: "Qex",
+      extras: [
+        "CHANGELOG.md": [],
+        "LICENSE.md": [title: "License"],
+        "README.md": [title: "Overview"]
+      ],
+      main: "readme",
       canonical: "http://hexdocs.pm/qex",
+      homepage_url: @source_url,
       source_url: @source_url,
-      extras: ["CHANGELOG.md"]
+      source_ref: "v#{@version}"
     ]
   end
 end


### PR DESCRIPTION
Besides other documentation changes, this commit ensures the generated
HTML doc for HexDocs.pm will become the source of truth for this Elixir
library and leverage on latest features of ExDoc.